### PR TITLE
add support for name-annotated types

### DIFF
--- a/lib/spect.ex
+++ b/lib/spect.ex
@@ -95,6 +95,10 @@ defmodule Spect do
     to_spec!(data, module, name)
   end
 
+  defp to_kind!(data, {:ann_type, _line, [{:var, _, _name}, type]}) do
+    to_kind!(data, type)
+  end
+
   defp to_kind!(data, {kind, _line, value}) do
     to_lit!(data, kind, value)
   end
@@ -389,7 +393,7 @@ defmodule Spect do
 
   # any typed map, recursive
   defp to_map!(data, [{:type, _line, _mode, [key_field, val_field]}])
-       when elem(key_field, 0) in [:type, :remote_type] do
+       when elem(key_field, 0) in [:type, :remote_type, :ann_type] do
     if is_map(data) do
       Enum.reduce(Map.to_list(data), %{}, fn {k, v}, r ->
         Map.put(r, to_kind!(k, key_field), to_kind!(v, val_field))

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Spect.MixProject do
     [
       app: :spect,
       name: "Spect",
-      version: "0.2.1",
+      version: "0.2.2",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: "Type specification extensions for Elixir.",

--- a/test/support/specs.ex
+++ b/test/support/specs.ex
@@ -28,10 +28,10 @@ defmodule Spect.Support.Specs do
 
   @type tuple_test :: {atom(), integer(), String.t()}
 
-  @type list_test :: [integer()]
+  @type list_test :: [e :: integer()]
 
-  @type map_test :: %{integer() => String.t()}
-  @type map_required_test :: %{required(atom()) => integer}
+  @type map_test :: %{(k :: integer()) => v :: String.t()}
+  @type map_required_test :: %{required(k :: atom()) => v :: integer}
   @type map_exact_test :: %{
           required(:key1) => integer(),
           required(:key2) => String.t(),


### PR DESCRIPTION
These changes allow you to name fields in typespecs, which generates `:ann_type` type descriptors.