### PR TITLE
Documentation updates / 0.3.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Type specification extensions for Elixir.
 [![CircleCI](https://circleci.com/gh/pylon/spect.svg?style=shield)](https://circleci.com/gh/pylon/spect)
 [![Coverage](https://coveralls.io/repos/github/pylon/spect/badge.svg)](https://coveralls.io/github/pylon/spect)
 
-The API reference is available [here](https://hexdocs.pm/spect/).
+The API reference is available [here](https://hexdocs.pm/spect/api-reference.html).
 
 ## Installation
 
@@ -108,16 +108,16 @@ Spect tries to do.
 
 ## License
 
-Copyright 2018 Pylon, Inc.
+Copyright 2019 Pylon, Inc.
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Spect.MixProject do
     [
       app: :spect,
       name: "Spect",
-      version: "0.3.1",
+      version: "0.3.2",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: "Type specification extensions for Elixir.",
@@ -22,7 +22,10 @@ defmodule Spect.MixProject do
         ignore_warnings: ".dialyzerignore",
         plt_add_deps: :transitive
       ],
-      docs: [extras: ["README.md"]]
+      docs: [
+        main: "readme",
+        extras: ["README.md"]
+      ]
     ]
   end
 


### PR DESCRIPTION
I made a few updates to the documentation for Hex, mainly to change the index to something a little more welcoming and to call out the support for multiple types and `DateTime`.

The recent dependency updates and minor change also call for a patch release, so I made that update as well.