### PR TITLE
parameterized user/remote types

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ def deps do
 end
 ```
 
+Note that if you use the `:strip_beams` option when compiling your project
+with [mix release](https://hexdocs.pm/mix/Mix.Release.html) or
+[mix escript.build](https://hexdocs.pm/mix/Mix.Tasks.Escript.Build.html),
+typespecs will not be included in the compiled beams, and spect will not
+be able to check/map your types.
+
 ## Features
 
 ### Structure Decoding

--- a/lib/spect.ex
+++ b/lib/spect.ex
@@ -126,13 +126,14 @@ defmodule Spect do
     to_type!(data, module, type, args, params)
   end
 
-  defp to_kind!(data, _module, {:remote_type, _line, type}, _params) do
-    [{:atom, _, module}, {:atom, _, name}, args] = type
+  defp to_kind!(data, module, {:remote_type, _line, type}, _params) do
+    [{:atom, _, remote_module}, {:atom, _, name}, args] = type
 
-    if module == DateTime and name == :t do
+    if remote_module == DateTime and name == :t do
       to_datetime!(data)
     else
-      to_spec!(data, module, name, args)
+      params = Enum.map(args, &{module, &1})
+      to_spec!(data, remote_module, name, params)
     end
   end
 
@@ -146,11 +147,13 @@ defmodule Spect do
   end
 
   defp to_kind!(data, module, {:user_type, _line, name, args}, _params) do
-    to_spec!(data, module, name, args)
+    params = Enum.map(args, &{module, &1})
+    to_spec!(data, module, name, params)
   end
 
-  defp to_kind!(data, module, {:var, _line, _value} = var, params) do
-    to_kind!(data, module, Map.fetch!(params, var), params)
+  defp to_kind!(data, _module, {:var, _line, _value} = var, params) do
+    {module, type} = Map.fetch!(params, var)
+    to_kind!(data, module, type, params)
   end
 
   defp to_kind!(data, _module, {kind, _line, value}, _params) do

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Spect.MixProject do
     [
       app: :spect,
       name: "Spect",
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: "Type specification extensions for Elixir.",

--- a/test/spect_test.exs
+++ b/test/spect_test.exs
@@ -200,7 +200,7 @@ defmodule Spect.Test do
     assert to_spec(nil, Specs, :maybe_int) === {:ok, nil}
 
     assert to_spec(%{test: "a"}, Specs.ParameterizedStruct) ===
-             {:ok, %Specs.ParameterizedStruct{test: "a"}}
+             {:ok, %Specs.ParameterizedStruct{test: :a}}
   end
 
   test "user_types" do

--- a/test/support/specs.ex
+++ b/test/support/specs.ex
@@ -94,8 +94,10 @@ defmodule Spect.Support.Specs do
   defmodule ParameterizedStruct do
     @moduledoc false
 
+    @type example_type :: :a | :b | :c | :d
+
     @type t :: %__MODULE__{
-            test: Spect.Support.Specs.maybe(binary())
+            test: Spect.Support.Specs.maybe(example_type)
           }
 
     defstruct [:test]


### PR DESCRIPTION
This change threads the source/referenced module along with the parameter information when instantiating parameterized types. This allows passing types that aren't in the parameterized type module.